### PR TITLE
Remove jekyll-tagging dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ The calculation algorithm is based on [related\_posts-jekyll\_plugin](https://gi
 
 * Ruby 2.3+
 * [Jekyll](https://github.com/jekyll/jekyll) 3.5+
-* [pattex/jekyll-tagging](https://github.com/pattex/jekyll-tagging)
 
 ## Installation
 
@@ -37,7 +36,6 @@ Edit `_config.yml` to use the plug-in:
 
 ```yml
 gems:
-  - jekyll/tagging
   - jekyll-tagging-related_posts
 ```
 

--- a/jekyll-tagging-related_posts.gemspec
+++ b/jekyll-tagging-related_posts.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.3"
 
   spec.add_runtime_dependency "jekyll", ">= 3.5", "< 5.0"
-  # spec.add_runtime_dependency "jekyll-tagging", "~> 1.0"
 
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "bundler"

--- a/jekyll-tagging-related_posts.gemspec
+++ b/jekyll-tagging-related_posts.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.3"
 
   spec.add_runtime_dependency "jekyll", ">= 3.5", "< 5.0"
-  spec.add_runtime_dependency "jekyll-tagging", "~> 1.0"
+  # spec.add_runtime_dependency "jekyll-tagging", "~> 1.0"
 
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
There’s no need to depend on jekyll-tagging, as the related posts functionality relies on the core tags functionality. The gem works just fine without the dependency.